### PR TITLE
Mordor config mod, fix reward calc

### DIFF
--- a/config/src/main/resources/mordor.json
+++ b/config/src/main/resources/mordor.json
@@ -1,12 +1,6 @@
 {
   "config": {
     "chainId": 63,
-    "homesteadBlock": 0,
-    "classicForkBlock": 0,
-    "ecip1015Block": 0,
-    "diehardBlock": 0,
-    "gothamBlock": 0,
-    "ecip1041Block": 0,
     "atlantisBlock": 0,
     "ethash": {}
   },


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
Changed mordor.json config to only include atlantisBlock attribute since
mordor is based on atlantis.  Setting other attributes with block value of 0 causes issues.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixed issue with rewardCoinbase function in ClassicBlockProcessor where
ommerReward for blocks less than 5,000,000 (Era 1) were calculated
incrorrectly.