### PR TITLE
config/resources: activate aztlan on mainnet block 10500839

### DIFF
--- a/config/src/main/resources/classic.json
+++ b/config/src/main/resources/classic.json
@@ -9,6 +9,7 @@
     "ecip1041Block": 5900000,
     "atlantisBlock": 8772000,
     "aghartaBlock": 9573000,
+    "aztlanBlock": 10500839,
     "ethash": {
 
     }


### PR DESCRIPTION
## PR description

activates aztlan on classic mainnet block 10500839 as per ecip 1061

https://github.com/ethereumclassic/ECIPs/blob/master/_specs/ecip-1061.md#abstract

tagged release upstream would be appreciated