### PR TITLE
update getForks to ignore ClassicForkBlock chain config parameter

### DIFF
--- a/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
+++ b/config/src/main/java/org/hyperledger/besu/config/GenesisConfigFile.java
@@ -138,6 +138,7 @@ public class GenesisConfigFile {
                     .filter(name -> !name.equals("chainid"))
                     .filter(name -> node.get(name).canConvertToLong())
                     .filter(name -> name.contains("block"))
+                    .filter(name -> !name.equals("classicforkblock"))
                     .map(name -> node.get(name).asLong()))
         .sorted()
         .collect(toUnmodifiableList());

--- a/config/src/test/java/org/hyperledger/besu/config/GenesisConfigFileTest.java
+++ b/config/src/test/java/org/hyperledger/besu/config/GenesisConfigFileTest.java
@@ -338,6 +338,26 @@ public class GenesisConfigFileTest {
     assertThat(config.getConfigOptions().getChainId()).hasValue(BigInteger.valueOf(4));
   }
 
+  @Test
+  public void shouldLoadForksIgnoreClassicForkBlock() throws IOException {
+    final ObjectNode configNode =
+        new ObjectMapper()
+            .createObjectNode()
+            .set(
+                "config",
+                JsonUtil.objectNodeFromString(
+                    Resources.toString(
+                        Resources.getResource(
+                            // If you inspect this config, you should see that classicForkBlock is
+                            // declared (which we want to ignore)
+                            "valid_config_with_etc_forks.json"),
+                        StandardCharsets.UTF_8)));
+    final GenesisConfigFile config = fromConfig(configNode);
+
+    assertThat(config.getForks()).containsExactly(1L, 2L, 3L, 3L, 1035301L);
+    assertThat(config.getConfigOptions().getChainId()).hasValue(BigInteger.valueOf(61));
+  }
+
   private GenesisConfigFile configWithProperty(final String key, final String value) {
     return fromConfig("{\"" + key + "\":\"" + value + "\"}");
   }

--- a/config/src/test/resources/valid_config_with_etc_forks.json
+++ b/config/src/test/resources/valid_config_with_etc_forks.json
@@ -1,0 +1,32 @@
+{
+  "chainId": 61,
+  "eip150Block": 2,
+  "homesteadBlock": 1,
+  "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "eip155Block": 3,
+  "eip158Block": 3,
+  "classicForkBlock": 1920000,
+  "byzantiumBlock": 1035301,
+  "ibft2": {
+    "blockperiodseconds": 2,
+    "epochlength": 30000,
+    "requesttimeoutseconds": 10
+  },
+  "transitions": {
+    "ibft2": [
+      {
+        "block": 20,
+        "validators": [
+          "0x1234567890123456789012345678901234567890",
+          "0x9876543210987654321098765432109876543210"
+        ]
+      },
+      {
+        "block": 25,
+        "validators": [
+          "0x1234567890123456789012345678901234567890"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Signed-off-by: Edward Mack <ed@edwardmack.com>

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/hyperledger/besu/blob/master/CONTRIBUTING.md -->

## PR description
This PR implements functionality to ignore `ClassicForkBlock` chain config parameter in getForks method.  Since getForks method is intended to list blocks when chains have forked, and the `ClassicForkBlock` parameter is to define when a fork on classic network did NOT happen, it should not be included in this list.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
Fixes issues regarding syncing with ETC mainnet.